### PR TITLE
[#4] Use pre-built image for docker4development

### DIFF
--- a/docker/planet-dev.yml
+++ b/docker/planet-dev.yml
@@ -7,13 +7,11 @@ services:
       - "2200:5984"
       - "2201:5986"
   db-init:
-    build:
-      context: ./db-init/
+    image: treehouses/planet-dev:db-init-latest
     depends_on:
       - couchdb
   planet:
-    build:
-      context: ./planet/
+    image: treehouses/planet-dev:latest
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
Requires testing and review.
- [x] Testing in local machine

At the time this PR created, the `latest` docker image is not ready yet, will have it soon in couple of hours (long upload time)