### PR TITLE
update login.compononent.ts to create admin on first time login (#53)

### DIFF
--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -48,11 +48,7 @@ export class LoginComponent {
 
     onSubmit() {
         if(this.createMode) {
-            if (this.checkAdminExistence()) {
-                this.createAdmin(this.model);
-            } else {
-                this.createUser(this.model);
-            }
+            this.checkAdminExistence()
         } else {
             this.login(this.model);
         }
@@ -70,7 +66,6 @@ export class LoginComponent {
                     this.reRoute();
                 }, (error) => {
                     this.message = '';
-                    console.log('Need admin privilage to create a user');
             });
         } else {
             this.message = 'Passwords do not match';
@@ -79,9 +74,8 @@ export class LoginComponent {
 
     createAdmin({name,password,repeatPassword}:{name:string,password:string,repeatPassword:string}) {
         if(password === repeatPassword) {
-            this.couchService.put('_node/nonode@nohost/_config/admins/' + name + ' -d ' + "'" + '"' + password + '"' + "'", {})
+            this.couchService.put('_node/nonode@nohost/_config/admins/' + name, password)
                 .then((data) => {
-                    this.message = 'Admin created: ' + data.id.replace('org.couchdb.user:','');
                     this.reRoute();
                 }, (error) => this.message = '');
         } else {
@@ -92,9 +86,9 @@ export class LoginComponent {
     checkAdminExistence() {
         this.couchService.get('_users/_all_docs')
             .then((data) => {
-                return true; //user can see data so there is no admin
+                this.createAdmin(this.model); //user can see data so there is no admin
             }, (error) => {
-                return false; //user doesn't have permission so there is no admin
+                this.createUser(this.model); //user doesn't have permission so there is an admin
             });
     }
 


### PR DESCRIPTION
As discussed in the Angular hangout yesterday, I am creating a working PR so the process will be more transparent. **Note**: Still a work in process!

Before Submitting, `checkNumberUsers` looks for existing users and if there aren't any, then creates an Admin user. This is fine for now but for production will need to be modified so that there is a *superUser* or *root* and the other *admins* only have privileges so nobody can go rogue. 

As described in CouchDB docs
> In our previous discussions, we dropped some keywords about how things without the Admin Party 
> work. First, there’s admin itself, which implies some sort of super user. Then there are privileges. Let’s 
> explore these terms a little more. 

To do:
- [ ] fix createAdmin `put` because does not actually creating an admin

Please provide feedback if you think this isn't heading the right direction, so I don't stray any further! 