### PR TITLE
Environment var for db

### DIFF
--- a/src/app/resources/resources-view.component.ts
+++ b/src/app/resources/resources-view.component.ts
@@ -36,7 +36,6 @@ export class ResourcesViewComponent implements OnInit {
   resourceSrc = '';
   pdfSrc: any;
   contentType = '';
-  // This url might need to be dynamic in final version
   urlPrefix = environment.couchAddress + 'resources/';
 
   ngOnInit() {

--- a/src/app/resources/resources-view.component.ts
+++ b/src/app/resources/resources-view.component.ts
@@ -5,6 +5,8 @@ import { CouchService } from '../shared/couchdb.service';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { DomSanitizer } from '@angular/platform-browser';
 
+import { environment } from '../../environments/environment';
+
 @Component({
   template: `
     <div [ngSwitch]="mediaType">
@@ -35,7 +37,7 @@ export class ResourcesViewComponent implements OnInit {
   pdfSrc: any;
   contentType = '';
   // This url might need to be dynamic in final version
-  urlPrefix = 'http://127.0.0.1:2200/resources/';
+  urlPrefix = environment.couchAddress + 'resources/';
 
   ngOnInit() {
     this.route.paramMap

--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -7,7 +7,7 @@ export class CouchService {
   private headers = new Headers({'Content-Type': 'application/json'});
   private defaultOpts = {headers: this.headers, withCredentials: true};
   // CouchDB ports are 2200 and 2201 (forwarded from 5984 and 5986 on virtual machine)
-  private baseUrl = 'http://127.0.0.1:' + environment.couchPort + '/';
+  private baseUrl = environment.couchAddress;
 
   private setOpts(opts?: any) {
     return Object.assign({}, this.defaultOpts, opts) || this.defaultOpts;

--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -6,7 +6,6 @@ import { environment } from '../../environments/environment';
 export class CouchService {
   private headers = new Headers({'Content-Type': 'application/json'});
   private defaultOpts = {headers: this.headers, withCredentials: true};
-  // CouchDB ports are 2200 and 2201 (forwarded from 5984 and 5986 on virtual machine)
   private baseUrl = environment.couchAddress;
 
   private setOpts(opts?: any) {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,5 @@
 export const environment = {
-  production: true
+  production: true,
+  // Change this to Docker address
+  couchAddress: 'http://127.0.0.1:2200/'
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  couchPort: '5984'
+  couchAddress: 'http://127.0.0.1:5984/'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,5 +5,5 @@
 
 export const environment = {
   production: false,
-  couchPort: '2200'
+  couchAddress: 'http://127.0.0.1:2200/'
 };


### PR DESCRIPTION
Related to #76, but doesn't fully add the different backend.  Uses environment variable for CouchDB/backend URL for all environments.