### PR TITLE
Bracket spacing rule for linting (Fixes #150)

### DIFF
--- a/e2e/userHandler.ts
+++ b/e2e/userHandler.ts
@@ -11,8 +11,8 @@ module.exports = function(timeStamp) {
       return rp({
         method: 'PUT',
         uri: 'http://127.0.0.1:5984/_users/org.couchdb.user:' + user,
-        headers: {'Content-Type': 'application/json'},
-        body: {name: user, password: 'e2e', roles: [], type: 'user'},
+        headers: { 'Content-Type': 'application/json' },
+        body: { name: user, password: 'e2e', roles: [], type: 'user' },
         json: true
       });
     },
@@ -22,7 +22,7 @@ module.exports = function(timeStamp) {
         return rp({
           method: 'DELETE',
           uri: 'http://127.0.0.1:5984/_users/org.couchdb.user:' + user + '?rev=' + rev,
-          headers: {'Content-Type': 'application/json'},
+          headers: { 'Content-Type': 'application/json' },
           json: true
         });
       });

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "request-promise": "^4.2.1",
     "ts-node": "~3.0.4",
     "tslint": "~5.3.2",
+    "tslint-eslint-rules": "^4.1.1",
     "typescript": "~2.3.3"
   }
 }

--- a/src/app/app-router.module.ts
+++ b/src/app/app-router.module.ts
@@ -5,13 +5,13 @@ import { PageNotFoundComponent } from './page-not-found/page-not-found.component
 import { AuthService } from './shared/auth-guard.service';
 
 export const routes: Routes = [
-  { path: '', loadChildren: './home/home.module#HomeModule', canActivateChild: [AuthService] },
+  { path: '', loadChildren: './home/home.module#HomeModule', canActivateChild: [ AuthService ] },
   { path: 'login', loadChildren: './login/login.module#LoginModule' },
   { path: '**', component: PageNotFoundComponent }
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
-  exports: [RouterModule]
+  imports: [ RouterModule.forRoot(routes) ],
+  exports: [ RouterModule ]
 })
 export class AppRoutingModule {}

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -7,8 +7,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 describe('App', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      declarations: [AppComponent]
+      imports: [ RouterTestingModule ],
+      declarations: [ AppComponent ]
     });
   });
 

--- a/src/app/courses/constants.ts
+++ b/src/app/courses/constants.ts
@@ -17,7 +17,7 @@ export const gradeLevels = [
   'Post-Graduate'
 ];
 
-export const subjectLevels = ['Beginner', 'Intermediate', 'Advanced', 'Expert'];
+export const subjectLevels = [ 'Beginner', 'Intermediate', 'Advanced', 'Expert' ];
 
 export const days = [
   'Saturday',

--- a/src/app/courses/courses.component.spec.ts
+++ b/src/app/courses/courses.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import {ReactiveFormsModule,FormsModule} from '@angular/forms';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { CoursesComponent } from './courses.component';
 import { FormErrorMessagesComponent } from '../form-error-messages/form-error-messages.component';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -13,10 +13,10 @@ describe('CoursesComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule,FormsModule,RouterTestingModule, HttpModule],
-      declarations: [ CoursesComponent,FormErrorMessagesComponent],
-      providers: [CouchService, CourseValidatorService ]
-      
+      imports: [ ReactiveFormsModule, FormsModule, RouterTestingModule, HttpModule ],
+      declarations: [ CoursesComponent, FormErrorMessagesComponent ],
+      providers: [ CouchService, CourseValidatorService ]
+
     })
     .compileComponents();
   }));

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -18,7 +18,7 @@ import searchDocuments, * as constants from './constants';
 @Component({
   selector: 'planet-courses',
   templateUrl: './courses.component.html',
-  styleUrls: ['./courses.component.scss']
+  styleUrls: [ './courses.component.scss' ]
 })
 export class CoursesComponent {
   // needs member document to implement
@@ -52,7 +52,7 @@ export class CoursesComponent {
         // an arrow function is for lexically binding 'this' otherwise 'this' would be undefined
         ac => this.courseValidatorService.checkCourseExists$(ac)
       ],
-      description: ['', Validators.required],
+      description: [ '', Validators.required ],
       languageOfInstruction: '',
       memberLimit: [
         '', // need to compose validators if we use more than one
@@ -61,11 +61,11 @@ export class CoursesComponent {
           Validators.min(1)
         ])
       ],
-      courseLeader: [''],
+      courseLeader: [ '' ],
       method: '',
       gradeLevel: '',
       subjectLevel: '',
-      startDate: ['', CustomValidators.dateValidator],
+      startDate: [ '', CustomValidators.dateValidator ],
       endDate: [
         '',
         Validators.compose([
@@ -75,7 +75,7 @@ export class CoursesComponent {
         ])
       ],
       day: this.fb.array([]),
-      startTime: ['', CustomValidators.timeValidator],
+      startTime: [ '', CustomValidators.timeValidator ],
       endTime: [
         '',
         Validators.compose([
@@ -84,8 +84,8 @@ export class CoursesComponent {
         ])
       ],
       location: '',
-      backgroundColor: ['', CustomValidators.hexValidator],
-      foregroundColor: ['', CustomValidators.hexValidator]
+      backgroundColor: [ '', CustomValidators.hexValidator ],
+      foregroundColor: [ '', CustomValidators.hexValidator ]
     });
 
     // set default values
@@ -112,7 +112,7 @@ export class CoursesComponent {
   async addCourse(courseInfo) {
     // ...is the rest syntax for object destructuring
     await this.couchService.post(this.dbName, { ...courseInfo });
-    this.router.navigate(['/']);
+    this.router.navigate([ '/' ]);
   }
 
   cancel() {

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -11,9 +11,9 @@ describe('Dashboard', () => {
 
   const setup = () => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      declarations: [DashboardComponent],
-      providers: [UserService]
+      imports: [ RouterTestingModule ],
+      declarations: [ DashboardComponent ],
+      providers: [ UserService ]
     });
     const fixture = TestBed.createComponent(DashboardComponent),
       comp = fixture.componentInstance,

--- a/src/app/home/home-router.module.ts
+++ b/src/app/home/home-router.module.ts
@@ -11,19 +11,19 @@ import { NationComponent } from '../nation/nation.component';
 const routes: Routes = [
   { path: '', component: HomeComponent,
     children: [
-      { path: '', component: DashboardComponent},
-      { path: 'users', component: UsersComponent},
-      { path: 'nation', component: NationComponent},
+      { path: '', component: DashboardComponent },
+      { path: 'users', component: UsersComponent },
+      { path: 'nation', component: NationComponent },
       { path: 'courses', component: CoursesComponent },
       { path: 'community', component: CommunityComponent },
-      { path: 'resources', loadChildren: '../resources/resources.module#ResourcesModule'},
-      { path: 'meetups', loadChildren: '../meetups/meetups.module#MeetupsModule'}
+      { path: 'resources', loadChildren: '../resources/resources.module#ResourcesModule' },
+      { path: 'meetups', loadChildren: '../meetups/meetups.module#MeetupsModule' }
     ]
   }
 ];
 
 @NgModule({
-  imports: [RouterModule.forChild(routes)],
-  exports: [RouterModule]
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
 })
 export class HomeRouterModule {}

--- a/src/app/home/home.compnent.spec.ts
+++ b/src/app/home/home.compnent.spec.ts
@@ -11,9 +11,9 @@ describe('Home', () => {
 
   const setup = () => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, CommonModule, HttpModule],
-      declarations: [HomeComponent, NavigationComponent],
-      providers: [CouchService]
+      imports: [ RouterTestingModule, CommonModule, HttpModule ],
+      declarations: [ HomeComponent, NavigationComponent ],
+      providers: [ CouchService ]
     });
     const fixture = TestBed.createComponent(HomeComponent),
       comp = fixture.componentInstance;

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -10,6 +10,6 @@ import { UserService } from '../shared/user.service';
       <router-outlet></router-outlet>
     </main>
   `,
-  styleUrls: ['./home.scss']
+  styleUrls: [ './home.scss' ]
 })
 export class HomeComponent {}

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -18,7 +18,7 @@ import { NationValidatorService } from '../validators/nation-validator.service';
 import { NationComponent } from '../nation/nation.component';
 
 @NgModule({
-  imports: [HomeRouterModule, CommonModule, FormsModule, ReactiveFormsModule],
+  imports: [ HomeRouterModule, CommonModule, FormsModule, ReactiveFormsModule ],
   declarations: [
     HomeComponent,
     DashboardComponent,
@@ -29,6 +29,6 @@ import { NationComponent } from '../nation/nation.component';
     FormErrorMessagesComponent,
     NationComponent
   ],
-  providers: [CourseValidatorService, NationValidatorService]
+  providers: [ CourseValidatorService, NationValidatorService ]
 })
 export class HomeModule {}

--- a/src/app/home/navigation.component.spec.ts
+++ b/src/app/home/navigation.component.spec.ts
@@ -20,8 +20,8 @@ describe('Navigation', () => {
 
   const setup = () => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, CommonModule, HttpModule],
-      declarations: [NavigationComponent],
+      imports: [ RouterTestingModule, CommonModule, HttpModule ],
+      declarations: [ NavigationComponent ],
       providers: [
         CouchService,
         { provide: Router, useClass: RouterStub }
@@ -51,19 +51,19 @@ describe('Navigation', () => {
     };
 
     it('Should call CouchService delete to logout', () => {
-      const { logoutButton, fixture } = setupLogin({ok: true});
+      const { logoutButton, fixture } = setupLogin({ ok: true });
       expect(couchSpy).toHaveBeenCalled();
     });
 
     it('Should redirect when logout succeeds', () => {
-      const { logoutButton, fixture } = setupLogin({ok: true});
+      const { logoutButton, fixture } = setupLogin({ ok: true });
       fixture.whenStable().then(() => {
         expect(routerSpy).toHaveBeenCalled();
       });
     });
 
     it('Should not redirect when logout fails', () => {
-      const { logoutButton, fixture } = setupLogin({ok: false});
+      const { logoutButton, fixture } = setupLogin({ ok: false });
       fixture.whenStable().then(() => {
         expect(routerSpy).not.toHaveBeenCalled();
       });

--- a/src/app/home/navigation.component.ts
+++ b/src/app/home/navigation.component.ts
@@ -11,7 +11,7 @@ import { Router } from '@angular/router';
       <li><a href="#" class="km-logout" (click)="logoutClick()">LOGOUT</a></li>
     </ul>
   `,
-  styleUrls: ['./navigation.scss']
+  styleUrls: [ './navigation.scss' ]
 })
 export class NavigationComponent {
   constructor(
@@ -32,7 +32,7 @@ export class NavigationComponent {
   logoutClick() {
     this.couchService.delete('_session', { withCredentials: true }).then((data: any) => {
       if (data.ok === true) {
-        this.router.navigate(['/login'], {});
+        this.router.navigate([ '/login' ], {});
       }
     });
   }

--- a/src/app/login/login-router.module.ts
+++ b/src/app/login/login-router.module.ts
@@ -9,7 +9,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forChild(routes)],
-  exports: [RouterModule]
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
 })
 export class LoginRouterModule {}

--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -17,16 +17,16 @@ describe('Login', () => {
 
   const setup = () => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes([]), FormsModule, CommonModule, HttpModule],
-      declarations: [LoginComponent],
-      providers: [CouchService]
+      imports: [ RouterTestingModule.withRoutes([]), FormsModule, CommonModule, HttpModule ],
+      declarations: [ LoginComponent ],
+      providers: [ CouchService ]
     });
     const fixture = TestBed.createComponent(LoginComponent),
       comp = fixture.componentInstance,
       de = fixture.debugElement.query(By.css('#login-status')),
       statusElement = de.nativeElement,
       couchService = fixture.debugElement.injector.get(CouchService),
-      testModel = {name: 'test', password: 'password', repeatPassword: 'password'};
+      testModel = { name: 'test', password: 'password', repeatPassword: 'password' };
     return { fixture, comp, statusElement, couchService, testModel };
   };
 
@@ -42,7 +42,7 @@ describe('Login', () => {
 
   it('Should display create user message', () => {
     const { fixture, comp, statusElement, couchService, testModel } = setup();
-    spy = spyOn(couchService, 'put').and.returnValue(Promise.resolve({id: 'org.couchdb.user:' + testModel.name}));
+    spy = spyOn(couchService, 'put').and.returnValue(Promise.resolve({ id: 'org.couchdb.user:' + testModel.name }));
     comp.createUser(testModel);
     fixture.whenStable().then(() => {
       fixture.detectChanges();

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -33,7 +33,7 @@ require('./login.scss');
       <div id="login-status">{{message}}</div>
     </div>
   `,
-  styleUrls: ['./login.scss']
+  styleUrls: [ './login.scss' ]
 
 })
 export class LoginComponent {
@@ -63,12 +63,12 @@ export class LoginComponent {
   }
 
   reRoute() {
-    this.router.navigate([this.returnUrl]);
+    this.router.navigate([ this.returnUrl ]);
   }
 
-  createUser({name, password, repeatPassword}: {name: string, password: string, repeatPassword: string}) {
+  createUser({ name, password, repeatPassword }: {name: string, password: string, repeatPassword: string}) {
     if (password === repeatPassword) {
-      this.couchService.put('_users/org.couchdb.user:' + name, {'name': name, 'password': password, 'roles': [], 'type': 'user'})
+      this.couchService.put('_users/org.couchdb.user:' + name, { 'name': name, 'password': password, 'roles': [], 'type': 'user' })
         .then((data) => {
           this.message = 'User created: ' + data.id.replace('org.couchdb.user:', '');
           this.reRoute();
@@ -78,7 +78,7 @@ export class LoginComponent {
     }
   }
 
-  createAdmin({name, password, repeatPassword}: {name: string, password: string, repeatPassword: string}) {
+  createAdmin({ name, password, repeatPassword }: {name: string, password: string, repeatPassword: string}) {
     if (password === repeatPassword) {
       this.couchService.put('_node/nonode@nohost/_config/admins/' + name, password)
         .then((data) => {
@@ -98,8 +98,8 @@ export class LoginComponent {
       });
   }
 
-  login({name, password}: {name: string, password: string}) {
-    this.couchService.post('_session', {'name': name, 'password': password}, { withCredentials: true })
+  login({ name, password }: {name: string, password: string}) {
+    this.couchService.post('_session', { 'name': name, 'password': password }, { withCredentials: true })
       .then((data) => {
         this.reRoute();
       }, (error) => this.message = 'Username and/or password do not match');

--- a/src/app/meetups/meetups-add.component.spec.ts
+++ b/src/app/meetups/meetups-add.component.spec.ts
@@ -10,7 +10,7 @@ describe('MeetupsAddComponent', () => {
     TestBed.configureTestingModule({
       imports: [ FormsModule, HttpModule ],
       declarations: [ MeetupsAddComponent ],
-      providers: [CouchService]
+      providers: [ CouchService ]
     })
     .compileComponents();
   }));

--- a/src/app/meetups/meetups-add.component.ts
+++ b/src/app/meetups/meetups-add.component.ts
@@ -33,7 +33,7 @@ export class MeetupsAddComponent implements OnInit {
   onSubmit(meetup) {
     if (meetup.description !== '' && meetup.title !== '') {
       console.log(meetup.description, meetup.title);
-      this.couchService.post('meetups', {'title': meetup.title, 'description': meetup.description})
+      this.couchService.post('meetups', { 'title': meetup.title, 'description': meetup.description })
         .then((data) => {
           this.message = 'Meetup created: ' + meetup.title;
         }, (error) => this.message = 'There was a problem creating the meetup');

--- a/src/app/meetups/meetups-router.module.ts
+++ b/src/app/meetups/meetups-router.module.ts
@@ -5,12 +5,12 @@ import { MeetupsComponent } from './meetups.component';
 import { MeetupsAddComponent } from './meetups-add.component';
 
 const routes: Routes = [
-  { path: '', component: MeetupsComponent},
-  { path: 'add', component: MeetupsAddComponent}
+  { path: '', component: MeetupsComponent },
+  { path: 'add', component: MeetupsAddComponent }
 ];
 
 @NgModule({
-  imports: [RouterModule.forChild(routes)],
-  exports: [RouterModule]
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
 })
 export class MeetupsRouterModule {}

--- a/src/app/meetups/meetups.component.spec.ts
+++ b/src/app/meetups/meetups.component.spec.ts
@@ -23,15 +23,15 @@ describe('MeetupsComponent', () => {
         HttpModule
       ],
       declarations: [ MeetupsComponent ],
-      providers: [CouchService]
+      providers: [ CouchService ]
     });
     fixture = TestBed.createComponent(MeetupsComponent);
     component = fixture.componentInstance;
     couchService = fixture.debugElement.injector.get(CouchService);
     de = fixture.debugElement;
-    meetupdata1 = {id: '1', rev: 'qwrjksf', title: 'happyhangout', description: 'once a week'};
-    meetupdata2 = {id: '2', rev: 'ghjjdrt', title: 'angularhangout', description: 'twice a week'};
-    meetuparray = {rows: [{doc: meetupdata1}, {doc: meetupdata2}]};
+    meetupdata1 = { id: '1', rev: 'qwrjksf', title: 'happyhangout', description: 'once a week' };
+    meetupdata2 = { id: '2', rev: 'ghjjdrt', title: 'angularhangout', description: 'twice a week' };
+    meetuparray = { rows: [ { doc: meetupdata1 }, { doc: meetupdata2 } ] };
   });
 
   it('should be created', () => {
@@ -39,7 +39,7 @@ describe('MeetupsComponent', () => {
   });
 
   it('should make a get request to couchService', () => {
-    getSpy = spyOn(couchService, 'get').and.returnValue(Promise.resolve({rows: []}));
+    getSpy = spyOn(couchService, 'get').and.returnValue(Promise.resolve({ rows: [] }));
     fixture.detectChanges();
     expect(getSpy).toHaveBeenCalledWith('meetups/_all_docs?include_docs=true');
   });

--- a/src/app/nation/nation.component.ts
+++ b/src/app/nation/nation.component.ts
@@ -41,13 +41,13 @@ export class NationComponent implements OnInit {
   }
   createForm() {
     this.nationForm = this.fb.group({
-      adminName: ['', Validators.required,
+      adminName: [ '', Validators.required,
         // an arrow function is for lexically binding 'this' otherwise 'this' would be undefined
         ac => this.nationValidatorService.nationCheckerService$(ac)
       ],
-      name: ['', Validators.required],
-      nationUrl: ['', Validators.required],
-      type: ['', Validators.required]
+      name: [ '', Validators.required ],
+      nationUrl: [ '', Validators.required ],
+      type: [ '', Validators.required ]
     });
   }
 
@@ -63,12 +63,12 @@ export class NationComponent implements OnInit {
       }, (error) => this.message = 'There was a problem getting NationList');
   }
 
-  deleteNation(nationId, nationRev, index){
-    const nationDelete = confirm('Are you sure you want to delete?')
-    if (nationDelete){
+  deleteNation(nationId, nationRev, index) {
+    const nationDelete = confirm('Are you sure you want to delete?');
+    if (nationDelete) {
       this.couchService.delete('nations/' + nationId + '?rev=' + nationRev)
       .then((data) => {
-        this.nation.splice(index,1);
+        this.nation.splice(index, 1);
       }, (error) => this.message = 'There was a problem deleting this meetup');
     }
   }
@@ -84,7 +84,7 @@ export class NationComponent implements OnInit {
         })
         .then((data) => {
         alert('Nation has been sucessfully created');
-        this.router.navigate(['nation']);
+        this.router.navigate([ 'nation' ]);
         location.reload();
       }, (error) => this.message = 'Error');
     } else {

--- a/src/app/resources/resources-router.module.ts
+++ b/src/app/resources/resources-router.module.ts
@@ -5,12 +5,12 @@ import { ResourcesComponent } from './resources.component';
 import { ResourcesViewComponent } from './resources-view.component';
 
 const routes: Routes = [
-  { path: '', component: ResourcesComponent},
-  { path: 'view/:id', component: ResourcesViewComponent}
+  { path: '', component: ResourcesComponent },
+  { path: 'view/:id', component: ResourcesViewComponent }
 ];
 
 @NgModule({
-  imports: [RouterModule.forChild(routes)],
-  exports: [RouterModule]
+  imports: [ RouterModule.forChild(routes) ],
+  exports: [ RouterModule ]
 })
 export class ResourcesRouterModule {}

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -34,10 +34,10 @@ export class ResourcesComponent implements OnInit {
     const fileData = reader.result.split(',')[1],
     attachments = {};
 
-    attachments[rComp.file.name] = {'content_type': rComp.file.type, 'data': fileData};
+    attachments[rComp.file.name] = { 'content_type': rComp.file.type, 'data': fileData };
 
     const resource = Object.assign({},
-      {'filename': rComp.file.name, '_id': rComp.file.name, '_attachments': attachments}, rComp.resource);
+      { 'filename': rComp.file.name, '_id': rComp.file.name, '_attachments': attachments }, rComp.resource);
 
     this.couchService.put('resources/' + rComp.file.name, resource)
       .then((data) => {

--- a/src/app/shared/auth-guard.service.ts
+++ b/src/app/shared/auth-guard.service.ts
@@ -16,7 +16,7 @@ export class AuthService {
           this.userService.set(res.userCtx);
           return true;
         }
-        this.router.navigate(['/login'], {queryParams: {returnUrl: url}, replaceUrl: true});
+        this.router.navigate([ '/login' ], { queryParams: { returnUrl: url }, replaceUrl: true });
         return false;
       });
   }

--- a/src/app/shared/couchdb.service.ts
+++ b/src/app/shared/couchdb.service.ts
@@ -4,8 +4,8 @@ import { environment } from '../../environments/environment';
 
 @Injectable()
 export class CouchService {
-  private headers = new Headers({'Content-Type': 'application/json'});
-  private defaultOpts = {headers: this.headers, withCredentials: true};
+  private headers = new Headers({ 'Content-Type': 'application/json' });
+  private defaultOpts = { headers: this.headers, withCredentials: true };
   private baseUrl = environment.couchAddress;
 
   private setOpts(opts?: any) {

--- a/src/app/users/users.component.spec.ts
+++ b/src/app/users/users.component.spec.ts
@@ -16,9 +16,9 @@ describe('Users', () => {
 
   const setup = () => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes([]), FormsModule, CommonModule, HttpModule],
-      declarations: [UsersComponent],
-      providers: [CouchService, UserService]
+      imports: [ RouterTestingModule.withRoutes([]), FormsModule, CommonModule, HttpModule ],
+      declarations: [ UsersComponent ],
+      providers: [ CouchService, UserService ]
     });
     const fixture = TestBed.createComponent(UsersComponent);
     const comp = fixture.componentInstance;
@@ -67,7 +67,7 @@ describe('Users', () => {
 
     it('Should display table for admin', () => {
       const { fixture, comp, userService } = setup(),
-        userSpy = spyOn(userService, 'get').and.returnValue({ roles: ['_admin'] });
+        userSpy = spyOn(userService, 'get').and.returnValue({ roles: [ '_admin' ] });
       comp.ngOnInit();
       fixture.whenStable().then(() => {
         fixture.detectChanges();
@@ -78,7 +78,7 @@ describe('Users', () => {
 
     it('Should make two GET requests to CouchDB for admin', () => {
       const { fixture, comp, userService, couchService } = setup(),
-        couchSpy = spyOn(couchService, 'get').and.returnValue(Promise.resolve({rows: []}));
+        couchSpy = spyOn(couchService, 'get').and.returnValue(Promise.resolve({ rows: [] }));
       comp.ngOnInit();
       comp.getUsers();
       comp.getAdmins();
@@ -97,8 +97,8 @@ describe('Users', () => {
         testEvent = { stopPropagation: () => { } },
         initSpy = spyOn(comp, 'initializeData').and.callFake(() => { } ),
         couchSpy = spyOn(couchService, 'put').and.returnValue(Promise.resolve({}));
-      comp.deleteRole({name: 'Test', roles: ['one', 'two', 'three']}, 1, testEvent);
-      expect(couchService.put).toHaveBeenCalledWith('_users/org.couchdb.user:Test', {name: 'Test', roles: ['one', 'three']});
+      comp.deleteRole({ name: 'Test', roles: [ 'one', 'two', 'three' ] }, 1, testEvent);
+      expect(couchService.put).toHaveBeenCalledWith('_users/org.couchdb.user:Test', { name: 'Test', roles: [ 'one', 'three' ] });
     });
 
   });

--- a/src/app/users/users.component.ts
+++ b/src/app/users/users.component.ts
@@ -48,7 +48,7 @@ export class UsersComponent implements OnInit {
   displayTable = true;
 
   // List of all possible roles to add to users
-  roleList: string[] = ['intern', 'learner', 'teacher'];
+  roleList: string[] = [ 'intern', 'learner', 'teacher' ];
   selectedRole = '';
 
   constructor(
@@ -94,7 +94,7 @@ export class UsersComponent implements OnInit {
         adminData = data[1];
       for (const key in adminData) {
         if (adminData.hasOwnProperty(key)) {
-          admins.push({name: key, roles: ['admin'], admin: true});
+          admins.push({ name: key, roles: [ 'admin' ], admin: true });
         }
       }
 

--- a/src/app/validators/course-validator.service.spec.ts
+++ b/src/app/validators/course-validator.service.spec.ts
@@ -10,7 +10,7 @@ describe('CourseValidatorService', () => {
     });
   });
 
-  it('should be created', inject([CourseValidatorService], (service: CourseValidatorService) => {
+  it('should be created', inject([ CourseValidatorService ], (service: CourseValidatorService) => {
     expect(service).toBeTruthy();
   }));
 });

--- a/src/app/validators/nation-validator.service.spec.ts
+++ b/src/app/validators/nation-validator.service.spec.ts
@@ -5,11 +5,11 @@ import { NationValidatorService } from './nation-validator.service';
 describe('NationValidatorService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [NationValidatorService]
+      providers: [ NationValidatorService ]
     });
   });
 
-  it('should be created', inject([NationValidatorService], (service: NationValidatorService) => {
+  it('should be created', inject([ NationValidatorService ], (service: NationValidatorService) => {
     expect(service).toBeTruthy();
   }));
 });

--- a/tslint.json
+++ b/tslint.json
@@ -2,7 +2,11 @@
   "rulesDirectory": [
     "node_modules/codelyzer"
   ],
+  "extends": [
+    "tslint-eslint-rules"
+  ],
   "rules": {
+    "array-bracket-spacing": "always",
     "arrow-return-shorthand": true,
     "callable-types": true,
     "class-name": true,
@@ -77,6 +81,7 @@
     "no-unused-expression": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,
+    "object-curly-spacing": "always",
     "object-literal-sort-keys": false,
     "one-line": [
       true,


### PR DESCRIPTION
I added in a new package which includes rules for bracket spacing so `[ myVar]` becomes `[ myVar ]` for both `[` and `{`.

The first commit just adds one line with the updated `package.json`, and the second one adds the rules to the `tslint.json`.  Put those in as separate commits so they don't get lost in the many lines of lint error fixes.

To use these rules you will have to run `npm install` in the vagrant.