### PR TITLE
add *.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ Thumbs.db
 
 # Virtual Machine
 .vagrant/
+
+# NPM/Yarn
+*.lock


### PR DESCRIPTION
Ignore the lock file created when running npm or yarn