### PR TITLE
A simple update in .travis.yml to have docker for production for x86

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,14 @@ language: node_js
 node_js:
   - "8"
 addons:
-  ssh_known_hosts: docker.ole.org
+  ssh_known_hosts: kraken.ole.org
   apt:
     sources:
       - google-chrome
     packages:
       - google-chrome-stable
       - google-chrome-beta
+      - docker-ce
 env:
   global:
     # DOCKER_USER


### PR DESCRIPTION
Requires nothing.

Result example: https://hub.docker.com/r/treehouses/planet/tags/