### PR TITLE
Change type for docker build (Fixes #189)

### DIFF
--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -13,7 +13,7 @@ export class CommunityComponent implements OnInit {
   selectedValue = '';
   selectedNation = '';
   nations = [];
-  deleteItem = {};
+  deleteItem: any;
 
   constructor(
     private couchService: CouchService

--- a/src/app/courses/courses.component.ts
+++ b/src/app/courses/courses.component.ts
@@ -9,7 +9,7 @@ declare var jQuery: any;
 export class CoursesComponent implements OnInit {
   message = '';
   courses = [];
-  deleteItem = {};
+  deleteItem: any;
   constructor(
     private couchService: CouchService
   ) { }

--- a/src/app/meetups/meetups.component.ts
+++ b/src/app/meetups/meetups.component.ts
@@ -8,7 +8,7 @@ declare var jQuery: any;
 export class MeetupsComponent implements OnInit {
   message = '';
   meetups = [];
-  deleteItem = {};
+  deleteItem: any;
 
   constructor(
     private couchService: CouchService

--- a/src/app/nation/nation.component.ts
+++ b/src/app/nation/nation.component.ts
@@ -23,8 +23,8 @@ export class NationComponent implements OnInit {
   message = '';
   nations = [];
   nationForm: FormGroup;
-  searchText='';
-  deleteItem = {};
+  searchText = '';
+  deleteItem: any;
 
   constructor(
     private location: Location,


### PR DESCRIPTION
This built correctly on my machine with `ng build --prod`, and hopefully this will fix the build for the Dockers as well.  I changed it for the two components that had errors as well as two others that have a similar variable in case that would cause these errors in the future.

Not sure exactly why these errors pop up in production mode and not development.  There must be some optimization for Webpack in production that relies on the variable types.