### PR TITLE
Fix app crashing 'EmptyError'

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "material-design-icons": "^3.0.1",
     "material-icons": "^0.1.0",
     "popper.js": "^1.12.9",
-    "rxjs": "^5.5.2",
+    "rxjs": "5.5.2",
     "zone.js": "^0.8.18"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes the error pictured in #211 which appears to be caused by a recent update to the rxjs package, or is at least fixed by using version 5.5.2 exactly rather than allowing `npm install` to install the latest, 5.5.3.

More details here:
https://github.com/angular/angular-cli/issues/8724