### PR TITLE
Update form error messages for Material and translations

### DIFF
--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -2,15 +2,15 @@
   <form class="addCourse-container" [formGroup]="courseForm" (ngSubmit)="onSubmit()" novalidate>
     <mat-grid-list cols="3">
       <mat-form-field>
-          <input matInput i18n-placeholder placeholder="Course Title" formControlName="courseTitle" required>
-          <mat-hint><planet-form-error-messages [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-hint>
+        <input matInput i18n-placeholder placeholder="Course Title" formControlName="courseTitle" required>
+        <mat-error><planet-form-error-messages [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
       </mat-form-field>
       <mat-form-field>
         <input matInput i18n-placeholder placeholder="Language of Instruction" formControlName="languageOfInstruction">
       </mat-form-field>
       <mat-form-field>
         <input matInput i18n-placeholder placeholder="Member Limit" type="number" class="example-right-align" formControlName="memberLimit">
-        <mat-hint><planet-form-error-messages [control]="courseForm.controls.memberLimit"></planet-form-error-messages></mat-hint>
+        <mat-error><planet-form-error-messages [control]="courseForm.controls.memberLimit"></planet-form-error-messages></mat-error>
       </mat-form-field>
     </mat-grid-list>
 
@@ -28,19 +28,19 @@
     <mat-grid-list cols="1">
       <mat-form-field>
         <textarea matInput i18n-placeholder placeholder="Description" formControlName="description" required></textarea>
+        <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
       </mat-form-field>
-      <planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages>
     </mat-grid-list>
 
     <mat-grid-list cols="2">
       <mat-form-field>
         <mat-select i18n-placeholder placeholder="Grade Level" formControlName="gradeLevel">
-          <mat-option *ngFor="let grade of gradeLevels" [value]="grade"> {{grade}} </mat-option>
+          <mat-option *ngFor="let grade of gradeLevels" [value]="grade">{{grade}}</mat-option>
         </mat-select>
       </mat-form-field>
       <mat-form-field>
         <mat-select i18n-placeholder placeholder="Subject Level" formControlName="subjectLevel">
-          <mat-option *ngFor="let sub of subjectLevels" [value]="sub"> {{sub}} </mat-option>
+          <mat-option *ngFor="let sub of subjectLevels" [value]="sub">{{sub}}</mat-option>
         </mat-select>
       </mat-form-field>
     </mat-grid-list>
@@ -48,15 +48,11 @@
     <mat-grid-list cols="3">
       <mat-form-field>
         <input matInput i18n-placeholder placeholder="Start Date" type="date" formControlName="startDate">
-        <mat-hint align="end">yyyy-mm-dd
-        <planet-form-error-messages [control]="courseForm.controls.startDate"></planet-form-error-messages>
-        </mat-hint>
+        <mat-error><planet-form-error-messages [control]="courseForm.controls.startDate"></planet-form-error-messages></mat-error>
       </mat-form-field>
       <mat-form-field>
         <input matInput type="date" i18n-placeholder placeholder="End Date" formControlName="endDate">
-        <mat-hint align="end">yyyy-mm-dd
-        <planet-form-error-messages [control]="courseForm.controls.endDate"></planet-form-error-messages>
-        </mat-hint>
+        <mat-error><planet-form-error-messages [control]="courseForm.controls.endDate"></planet-form-error-messages></mat-error>
       </mat-form-field>
 
       <label i18n>Frequency</label>
@@ -78,15 +74,11 @@
     <mat-grid-list cols="3">
       <mat-form-field>
         <input matInput type="time" i18n-placeholder placeholder="Start Time" formControlName="startTime">
-        <mat-hint align="end">hh:mm
-          <planet-form-error-messages [control]="courseForm.controls.startTime"></planet-form-error-messages>
-        </mat-hint>
+        <mat-error><planet-form-error-messages [control]="courseForm.controls.startTime"></planet-form-error-messages></mat-error>
       </mat-form-field>
       <mat-form-field>
         <input matInput type="time" i18n-placeholder placeholder="End Time" formControlName="endTime">
-        <mat-hint align="end">hh:mm
-          <planet-form-error-messages [control]="courseForm.controls.endTime"></planet-form-error-messages>
-        </mat-hint>
+        <mat-error><planet-form-error-messages [control]="courseForm.controls.endTime"></planet-form-error-messages></mat-error>
       </mat-form-field>
       <mat-form-field>
         <input matInput i18n-placeholder placeholder="Location" formControlName="location">
@@ -96,10 +88,10 @@
     <mat-grid-list cols="2">
       <label class="selectColor" i18n>Background Color</label>
         <input type="color" i18n-placeholder placeholder="Background Color" formControlName="backgroundColor" mat-icon>
-        <planet-form-error-messages [control]="courseForm.controls.backgroundColor"></planet-form-error-messages>
+        <mat-error><planet-form-error-messages [control]="courseForm.controls.backgroundColor"></planet-form-error-messages></mat-error>
       <label i18n>Foreground Color</label>
         <input type="color" i18n-placeholder placeholder="Foreground Color" formControlName="foregroundColor" mat-icon >
-        <planet-form-error-messages [control]="courseForm.controls.foregroundColor"></planet-form-error-messages>
+        <mat-error><planet-form-error-messages [control]="courseForm.controls.foregroundColor"></planet-form-error-messages></mat-error>
     </mat-grid-list>
 
     <mat-grid-list cols="2">

--- a/src/app/shared/dialogs/dialogs-form.component.html
+++ b/src/app/shared/dialogs/dialogs-form.component.html
@@ -1,22 +1,21 @@
 <form novalidate (ngSubmit)="onSubmit(modalForm.value, dialogRef)" [formGroup]="modalForm">
-  <div>
-    <h1 mat-dialog-title><span><mat-icon>create</mat-icon>{{title}}</span></h1>
-  </div>
-  <div mat-dialog-content>
+  <h1 mat-dialog-title><span><mat-icon>create</mat-icon>{{title}}</span></h1>
+  <mat-dialog-content>
     <div *ngFor="let field of fields">
-      <!-- textbox -->
-      <mat-input-container *ngIf="field.type == 'textbox'" class="modalForm-full-width">
-          <input matInput (keypress)="valueChange($event)" placeholder="{{field.placeholder}}" formControlName="{{field.name}}" required="{{field.required}}">
-      </mat-input-container>
+      <!-- input field -->
+      <mat-form-field *ngIf="field.type == 'textbox'" class="full-width">
+        <input matInput (keypress)="valueChange($event)" placeholder="{{field.placeholder}}" formControlName="{{field.name}}" required="{{field.required}}">
+        <mat-error><planet-form-error-messages [control]="modalForm.controls[field.name]"></planet-form-error-messages></mat-error>
+      </mat-form-field>
       <!-- selectbox -->
-      <mat-input-container *ngIf="field.type == 'selectbox'" class="modalForm-full-width">
+      <mat-form-field *ngIf="field.type == 'selectbox'" class="full-width">
         <select mat-select *ngFor="let options of field.options">
           <option value="{{option.value}}">{{option.text}}</option>
         </select>
-      </mat-input-container>
-      <planet-form-error-messages [control]="modalForm.controls[field.name]"></planet-form-error-messages>
+        <mat-error><planet-form-error-messages [control]="modalForm.controls[field.name]"></planet-form-error-messages></mat-error>
+      </mat-form-field>
     </div>
-  </div>
+  </mat-dialog-content>
   <mat-dialog-actions>
     <button color="warn" type="button" mat-raised-button (click)="dialogRef.close()" i18n>Cancel</button>&nbsp;
     <button type="submit" color="primary" mat-raised-button i18n>Submit</button>

--- a/src/app/shared/dialogs/dialogs-form.component.ts
+++ b/src/app/shared/dialogs/dialogs-form.component.ts
@@ -9,11 +9,7 @@ import {
 } from '@angular/forms';
 
 @Component({
-  templateUrl: './dialogs-form.component.html',
-  styles: [ `.modalForm-full-width {
-      width: 28em;
-    }
-  ` ]
+  templateUrl: './dialogs-form.component.html'
 })
 export class DialogsFormComponent {
 

--- a/src/app/shared/form-error-messages.component.ts
+++ b/src/app/shared/form-error-messages.component.ts
@@ -13,8 +13,7 @@ import { AbstractControl, AbstractControlDirective } from '@angular/forms';
     <span *ngIf="shouldShowError()" i18n>{updateError(), select,
       required {This field is required}
       min {The number cannot be below {{number}}}
-      duplicateCourse {This course already exists}
-      duplicateNation {This nation already exists}
+      duplicate {Value already exists}
       invalidInt {Please enter a number}
       invalidHex {Hex is not valid}
       invalidTime {Time is invalid}

--- a/src/app/shared/form-error-messages.component.ts
+++ b/src/app/shared/form-error-messages.component.ts
@@ -47,8 +47,4 @@ export class FormErrorMessagesComponent {
     return errorType;
   }
 
-  // calls the static method errorMessages
-  private getMessage(type: string, params: any) {
-    return FormErrorMessagesComponent.errorMessages[type](params);
-  }
 }

--- a/src/app/shared/form-error-messages.component.ts
+++ b/src/app/shared/form-error-messages.component.ts
@@ -1,39 +1,38 @@
+/**
+ * Centralized component for all form error messages
+ * MUST BE WRAPPED IN A mat-error ELEMENT
+ * Takes a form control as input and outputs a span element with the error message
+ */
+
 import { Component, Input } from '@angular/core';
 import { AbstractControl, AbstractControlDirective } from '@angular/forms';
 
 @Component({
   selector: 'planet-form-error-messages',
   template: `
-    <ul class="text-danger" *ngIf="shouldShowErrors()">
-      <li *ngFor="let error of listOfErrors()">{{error}}</li>
-    </ul>
-  `,
-  styles: [
-    `ul {
-      list-style-type: none;
-      font-size: .8rem;
-      padding-left: .2em;
-    }`
-  ]
+    <span *ngIf="shouldShowError()" i18n>{updateError(), select,
+      required {This field is required}
+      min {The number cannot be below {{number}}}
+      duplicateCourse {This course already exists}
+      duplicateNation {This nation already exists}
+      invalidInt {Please enter a number}
+      invalidHex {Hex is not valid}
+      invalidTime {Time is invalid}
+      invalidDateFormat {Date is in incorrect format}
+      invalidDate {Date is invalid}
+      invalidEndDate {End date cannot be before start date}
+      invalidEndTime {End time cannot be before start time}
+    }</span>
+  `
 })
 export class FormErrorMessagesComponent {
-  private static readonly errorMessages = {
-    // even though they have the same return type, different names are used since it's more clear & easier to understand/debug
-    required: () => 'This field is required',
-    min: params => 'The number cannot be below ' + params.min,
-    duplicateCourse: params => params.message,
-    duplicateNation: params => params.message,
-    invalidInt: params => params.message,
-    invalidHex: params => params.message,
-    invalidTime: params => params.message,
-    invalidDateFormat: params => params.message,
-    invalidDate: params => params.message,
-    invalidEndDate: params => params.message,
-    inavlidEndTime: params => params.message
-  };
+
   @Input() private control: AbstractControlDirective | AbstractControl;
 
-  shouldShowErrors(): boolean {
+  error = '';
+  number = 0;
+
+  shouldShowError(): boolean {
     return (
       this.control &&
       this.control.errors &&
@@ -41,14 +40,14 @@ export class FormErrorMessagesComponent {
     );
   }
 
-  // loops through the keys of the error objectt
-  listOfErrors(): string[] {
-    return Object.keys(this.control.errors).map(field =>
-      this.getMessage(field, this.control.errors[field])
-    );
+  // Show one error at a time
+  updateError(): string {
+    const errorType = Object.keys(this.control.errors)[0];
+    this.number = this.control.errors[errorType].min || this.control.errors[errorType].max || 0;
+    return errorType;
   }
 
-  // calls the statuc method errorMessages
+  // calls the static method errorMessages
   private getMessage(type: string, params: any) {
     return FormErrorMessagesComponent.errorMessages[type](params);
   }

--- a/src/app/shared/planet-forms.module.ts
+++ b/src/app/shared/planet-forms.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MaterialModule } from './material.module';
 import { FormErrorMessagesComponent } from './form-error-messages.component';
 
 @NgModule({
   imports: [
-    CommonModule
+    CommonModule, MaterialModule
   ],
   exports: [
     FormErrorMessagesComponent

--- a/src/app/validators/course-validator.service.ts
+++ b/src/app/validators/course-validator.service.ts
@@ -31,15 +31,12 @@ export class CourseValidatorService {
   public checkCourseExists$(
     ac: AbstractControl
   ): Observable<ValidationErrors | null> {
-    const errMessage = {
-      duplicateCourse: { message: 'Course already exists' }
-    };
     // calls service every .5s for input change
     return timer(500).pipe(
         switchMap(() => {
           return this.courseCheckerService$(ac.value).pipe(map(res => {
             if (res) {
-              return errMessage;
+              return { duplicate: true };
             }
             return null;
           }));

--- a/src/app/validators/custom-validators.ts
+++ b/src/app/validators/custom-validators.ts
@@ -5,22 +5,11 @@ import { takeUntil } from 'rxjs/operators';
 export class CustomValidators {
   // these validators are for cases when the browser does not support input type=date,time and color and the browser falls back to type=text
   static integerValidator(ac: AbstractControl): ValidationErrors {
-    const errMessage = {
-      invalidInt: {
-        message: 'Please enter a valid number'
-      }
-    };
-
     const isValidInt = Number.isInteger(ac.value);
-    return isValidInt ? null : errMessage;
+    return isValidInt ? null : { invalidInt: true };
   }
 
   static hexValidator(ac: AbstractControl): ValidationErrors {
-    const errMessage = {
-      invalidHex: {
-        message: 'Hex is not valid'
-      }
-    };
 
     if (!ac.value) {
       return null;
@@ -28,15 +17,10 @@ export class CustomValidators {
 
     const isValidHex = /^#[A-F0-9]{6}$/i.test(ac.value);
 
-    return isValidHex ? null : errMessage;
+    return isValidHex ? null : { invalidHex: true };
   }
 
   static timeValidator(ac: AbstractControl): ValidationErrors {
-    const errMessage = {
-      invalidTime: {
-        message: 'Time must be in the form hh:mm'
-      }
-    };
 
     if (!ac.value) {
       return null;
@@ -45,15 +29,10 @@ export class CustomValidators {
     // the regex is for hh:mm because input type=time always evaluates to this form regardless of how it may appear to the user
     const isValidTime = /^([01]?[0-9]|2[0-3]):[0-5][0-9]?$/.test(ac.value);
 
-    return isValidTime ? null : errMessage;
+    return isValidTime ? null : { invalidTime: true };
   }
 
   static dateValidator(ac: AbstractControl): ValidationErrors {
-    const formErrMessage = {
-      invalidDateFormat: {
-        message: 'Date must be in the form of yyyy-mm-dd'
-      }
-    };
 
     if (!ac.value) {
       return null;
@@ -63,18 +42,13 @@ export class CustomValidators {
     const dateRegEx = /^\d{4}-\d{2}-\d{2}/;
 
     if (!ac.value.match(dateRegEx)) {
-      return formErrMessage;
+      return { invalidDateFormat: true };
     }
+
     const date = new Date(ac.value);
 
-    const errMessage = {
-      invalidDate: {
-        message: 'Date is invalid'
-      }
-    };
-
     if (!date.getTime()) {
-      return errMessage;
+      return { invalidDate: true };
     }
 
     return null;
@@ -87,12 +61,6 @@ export class CustomValidators {
 
     // for unsubscribing from Observables
     const ngUnsubscribe: Subject<void> = new Subject<void>();
-
-    const errMessage = {
-      invalidEndDate: {
-        message: 'The end date cannot be before the start date'
-      }
-    };
 
     return (ac: AbstractControl): ValidationErrors => {
       if (!ac.parent) {
@@ -123,7 +91,7 @@ export class CustomValidators {
       if (
         new Date(startDate.value).getTime() > new Date(endDate.value).getTime()
       ) {
-        return errMessage;
+        return { invalidEndDate: true };
       }
     };
   }
@@ -133,11 +101,7 @@ export class CustomValidators {
     let startTime: AbstractControl;
     let endTime: AbstractControl;
     const ngUnsubscribe: Subject<void> = new Subject<void>();
-    const errMessage = {
-      inavlidEndTime: {
-        message: 'The end time cannot be before the start time'
-      }
-    };
+
     return (ac: AbstractControl): { [key: string]: any } => {
       if (!ac.parent) {
         return null;
@@ -166,9 +130,9 @@ export class CustomValidators {
       // cannot directly convert time (HH:MM) to Date object so changed it to a Unix time date
       if (
         new Date('1970-1-1 ' + startTime.value).getTime() >
-        new Date('1970-1-1 ' + endTime.value).getTime()
+        new Date(endTime.value && '1970-1-1 ' + endTime.value).getTime()
       ) {
-        return errMessage;
+        return { invalidEndTime: true };
       }
     };
   }

--- a/src/app/validators/nation-validator.service.ts
+++ b/src/app/validators/nation-validator.service.ts
@@ -29,15 +29,12 @@ export class NationValidatorService {
     header: string,
     ac: AbstractControl
   ): Observable<ValidationErrors | null> {
-    const errMessage = {
-      duplicateNation: { message : header === 'name' ? 'Nation already exists' : 'Nation URL already exists' }
-    };
     // calls service every .5s for input change
     return timer(500).pipe(
       switchMap(() => {
         return this.nationCheckerService$(header, ac.value).pipe(map(res => {
           if (res) {
-            return errMessage;
+            return { duplicate: true };
           }
           return null;
         }));

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -10,6 +10,10 @@ body {
     color: inherit;
   }
 
+  .full-width {
+    width: 100%;
+  }
+
   // STYLING FOR TABLE LIST ENTRIES
   .list-item {
     display: grid;


### PR DESCRIPTION
Updates the `form-error-messages.component.ts` for use with Material and the i18n translations.

To get the `mat-error` component to display correctly it had to be a direct descendant of `mat-form-field`, so I had to make adjustments to the `courses-add.component` and `dialogs-form.component`.