### PR TITLE
Fix the course add view

### DIFF
--- a/src/app/courses/add-courses/courses-add.component.html
+++ b/src/app/courses/add-courses/courses-add.component.html
@@ -1,103 +1,101 @@
 <h1 i18n>Add Courses</h1>
-  <form class="display-flex" [formGroup]="courseForm" (ngSubmit)="onSubmit()" novalidate>
-    <mat-grid-list cols="3">
-      <mat-form-field>
-        <input matInput i18n-placeholder placeholder="Course Title" formControlName="courseTitle" required>
-        <mat-error><planet-form-error-messages [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
-      </mat-form-field>
-      <mat-form-field>
-        <input matInput i18n-placeholder placeholder="Language of Instruction" formControlName="languageOfInstruction">
-      </mat-form-field>
-      <mat-form-field>
-        <input matInput i18n-placeholder placeholder="Member Limit" type="number" formControlName="memberLimit">
-        <mat-error><planet-form-error-messages [control]="courseForm.controls.memberLimit"></planet-form-error-messages></mat-error>
-      </mat-form-field>
-    </mat-grid-list>
+<form [formGroup]="courseForm" (ngSubmit)="onSubmit()" novalidate>
+  <div>
+    <mat-form-field>
+      <input matInput i18n-placeholder placeholder="Course Title" formControlName="courseTitle" required>
+      <mat-error><planet-form-error-messages [control]="courseForm.controls.courseTitle"></planet-form-error-messages></mat-error>
+    </mat-form-field>
+    <mat-form-field>
+      <input matInput i18n-placeholder placeholder="Language of Instruction" formControlName="languageOfInstruction">
+    </mat-form-field>
+    <mat-form-field>
+      <input matInput i18n-placeholder placeholder="Member Limit" type="number" formControlName="memberLimit">
+      <mat-error><planet-form-error-messages [control]="courseForm.controls.memberLimit"></planet-form-error-messages></mat-error>
+    </mat-form-field>
+  </div>
 
-    <mat-grid-list cols="2">
-      <mat-form-field>
-        <mat-select i18n-placeholder placeholder="Course Leader" formControlName="courseLeader">
-          <mat-option *ngFor="let memb of members" value={{memb?.id}}> {{memb?.doc.firstName}} {{memb?.doc.middleName}} {{memb?.doc.lastName}}</mat-option>
-        </mat-select>
-      </mat-form-field>
-      <mat-form-field>
-        <input matInput i18n-placeholder placeholder="Method" formControlName="method">
-      </mat-form-field>
-    </mat-grid-list>
+  <div>
+    <mat-form-field>
+      <mat-select i18n-placeholder placeholder="Course Leader" formControlName="courseLeader">
+        <mat-option *ngFor="let memb of members" value={{memb?.id}}> {{memb?.doc.firstName}} {{memb?.doc.middleName}} {{memb?.doc.lastName}}</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field>
+      <input matInput i18n-placeholder placeholder="Method" formControlName="method">
+    </mat-form-field>
+  </div>
 
-    <mat-grid-list cols="1">
-      <mat-form-field>
-        <textarea matInput i18n-placeholder placeholder="Description" formControlName="description" required></textarea>
-        <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
-      </mat-form-field>
-    </mat-grid-list>
+  <div>
+    <mat-form-field>
+      <textarea matInput i18n-placeholder placeholder="Description" formControlName="description" required></textarea>
+      <mat-error><planet-form-error-messages [control]="courseForm.controls.description"></planet-form-error-messages></mat-error>
+    </mat-form-field>
+  </div>
 
-    <mat-grid-list cols="2">
-      <mat-form-field>
-        <mat-select i18n-placeholder placeholder="Grade Level" formControlName="gradeLevel">
-          <mat-option *ngFor="let grade of gradeLevels" [value]="grade">{{grade}}</mat-option>
-        </mat-select>
-      </mat-form-field>
-      <mat-form-field>
-        <mat-select i18n-placeholder placeholder="Subject Level" formControlName="subjectLevel">
-          <mat-option *ngFor="let sub of subjectLevels" [value]="sub">{{sub}}</mat-option>
-        </mat-select>
-      </mat-form-field>
-    </mat-grid-list>
+  <div>
+    <mat-form-field>
+      <mat-select i18n-placeholder placeholder="Grade Level" formControlName="gradeLevel">
+        <mat-option *ngFor="let grade of gradeLevels" [value]="grade">{{grade}}</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field>
+      <mat-select i18n-placeholder placeholder="Subject Level" formControlName="subjectLevel">
+        <mat-option *ngFor="let sub of subjectLevels" [value]="sub">{{sub}}</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
 
-    <mat-grid-list cols="3">
-      <mat-form-field>
-        <input matInput i18n-placeholder placeholder="Start Date" type="date" formControlName="startDate">
-        <mat-error><planet-form-error-messages [control]="courseForm.controls.startDate"></planet-form-error-messages></mat-error>
-      </mat-form-field>
-      <mat-form-field>
-        <input matInput type="date" i18n-placeholder placeholder="End Date" formControlName="endDate">
-        <mat-error><planet-form-error-messages [control]="courseForm.controls.endDate"></planet-form-error-messages></mat-error>
-      </mat-form-field>
-
+  <div>
+    <mat-form-field>
+      <input matInput i18n-placeholder placeholder="Start Date" type="date" formControlName="startDate">
+      <mat-error><planet-form-error-messages [control]="courseForm.controls.startDate"></planet-form-error-messages></mat-error>
+    </mat-form-field>
+    <mat-form-field>
+      <input matInput type="date" i18n-placeholder placeholder="End Date" formControlName="endDate">
+      <mat-error><planet-form-error-messages [control]="courseForm.controls.endDate"></planet-form-error-messages></mat-error>
+    </mat-form-field>
+    <mat-radio-group>
       <label i18n>Frequency</label>
-        <mat-radio-group>
-          <mat-radio-button value="true" name="daysToggler" (change)="toogleWeekly(true)" i18n> Daily </mat-radio-button>
-          <mat-radio-button value="false" name="daysToggler" (change)="toogleWeekly(false)" i18n> Weekly </mat-radio-button>
-        </mat-radio-group>
-    </mat-grid-list>
+      <mat-radio-button value="true" name="daysToggler" (change)="toogleWeekly(true)" i18n>Daily</mat-radio-button>
+      <mat-radio-button value="false" name="daysToggler" (change)="toogleWeekly(false)" i18n>Weekly</mat-radio-button>
+    </mat-radio-group>
+  </div>
 
-    <mat-grid-list cols="1">
-      <div *ngIf="!showDaysCheckBox">
-        <label i18n>Day</label>
-        <mat-checkbox (change)="onDayChange(day, $event.checked)" *ngFor="let day of days"> {{day}} </mat-checkbox>
-      </div>
-    </mat-grid-list>
+  <div *ngIf="!showDaysCheckBox">
+    <label i18n>Day</label>
+    <mat-checkbox (change)="onDayChange(day, $event.checked)" *ngFor="let day of days" class="margin-lr">{{day}}</mat-checkbox>
+  </div>
 
-    <mat-grid-list cols="3">
-      <mat-form-field>
-        <input matInput type="time" i18n-placeholder placeholder="Start Time" formControlName="startTime">
-        <mat-error><planet-form-error-messages [control]="courseForm.controls.startTime"></planet-form-error-messages></mat-error>
-      </mat-form-field>
-      <mat-form-field>
-        <input matInput type="time" i18n-placeholder placeholder="End Time" formControlName="endTime">
-        <mat-error><planet-form-error-messages [control]="courseForm.controls.endTime"></planet-form-error-messages></mat-error>
-      </mat-form-field>
-      <mat-form-field>
-        <input matInput i18n-placeholder placeholder="Location" formControlName="location">
-      </mat-form-field>
-    </mat-grid-list>
+  <div>
+    <mat-form-field>
+      <input matInput type="time" i18n-placeholder placeholder="Start Time" formControlName="startTime">
+      <mat-error><planet-form-error-messages [control]="courseForm.controls.startTime"></planet-form-error-messages></mat-error>
+    </mat-form-field>
+    <mat-form-field>
+      <input matInput type="time" i18n-placeholder placeholder="End Time" formControlName="endTime">
+      <mat-error><planet-form-error-messages [control]="courseForm.controls.endTime"></planet-form-error-messages></mat-error>
+    </mat-form-field>
+    <mat-form-field>
+      <input matInput i18n-placeholder placeholder="Location" formControlName="location">
+    </mat-form-field>
+  </div>
 
-    <mat-grid-list cols="2">
-      <label i18n>Background Color</label>
-        <input type="color" i18n-placeholder placeholder="Background Color" formControlName="backgroundColor" mat-icon>
-        <mat-error><planet-form-error-messages [control]="courseForm.controls.backgroundColor"></planet-form-error-messages></mat-error>
-      <label i18n>Foreground Color</label>
-        <input type="color" i18n-placeholder placeholder="Foreground Color" formControlName="foregroundColor" mat-icon >
-        <mat-error><planet-form-error-messages [control]="courseForm.controls.foregroundColor"></planet-form-error-messages></mat-error>
-    </mat-grid-list>
+  <div>
+    <label i18n>Background Color</label>
+    <input type="color" i18n-placeholder placeholder="Background Color" formControlName="backgroundColor" mat-icon>
+    <mat-error><planet-form-error-messages [control]="courseForm.controls.backgroundColor"></planet-form-error-messages></mat-error>
+    <label i18n>Foreground Color</label>
+    <input type="color" i18n-placeholder placeholder="Foreground Color" formControlName="foregroundColor" mat-icon >
+    <mat-error><planet-form-error-messages [control]="courseForm.controls.foregroundColor"></planet-form-error-messages></mat-error>
+  </div>
 
-    <mat-grid-list cols="2">
-      <button type="submit" mat-raised-button color="primary" i18n>Submit</button>
-      <button type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>
-    </mat-grid-list>
-  </form>
+  <div>
+    <button type="submit" mat-raised-button color="primary" i18n>Submit</button>
+    <button type="button" mat-raised-button color="warn" (click)="cancel()" i18n>Cancel</button>
+  </div>
+</form>
 
+<!--FOR DEBUGGING (remove once view is final)-->
 <div>
   <p>Form value: {{ courseForm.value | json }}</p>
   <p>{{ courseForm.valid }}</p>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -34,9 +34,14 @@ body {
   .font-size-1 {
     font-size: 1rem;
   }
-  
+
   .full-width {
     width: 100%;
+  }
+
+  // Use to give elements horizontal space
+  .margin-lr {
+    margin: 0 5px;
   }
 
   // STYLING FOR TABLE LIST ENTRIES


### PR DESCRIPTION
The course view ended up a bit off due to a mixing up PRs on my part.  This returns the view to its previous horizontal alignment of input boxes.

There are two other changes included:
* The `mat-grid-list` was not being used correctly, so I removed them in favor of `div` elements.  Please take a close look at the examples [here](https://material.angular.io/components/grid-list/overview) and note that to work correctly these require `mat-grid-tile` children.
* I added a class `margin-lr` which can be used where the material components do not leave horizontal space between elements, like the day of the week checkboxes in this component.  I think this will be useful in other situations as well.