### PR TITLE
Update guidelines and move higher in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ Project to create a prototype for a reboot of the BeLL apps using Angular4 & Cou
 
 The only prequisite is Vagrant.  After cloning the repository, run `vagrant up` in the console.  Once it's done installing the virtual machine it'll automatically start compiling the app.  After about 10 seconds, you can open the app at `localhost:3000`
 
+## Project guidelines
+
+* Please check out [the project page](https://waffle.io/ole-vi/planet) for available tasks to work on.
+* Before contributing also be sure to read our [style guide](Style-Guide.md)
+* Please clone the repository rather than forking.  It's easier for us to collaborate from a new branch on the same repository.
+* After cloning the repository please run `npm run install-hooks` to add the git hooks to your local repository.
+* If you see something that needs work, please create an issue.  If the issue is on the frontend, please try to make it specific to one component.
+* To work on an issue, create a new branch with a descriptive title.
+* Please wait for at least two positive reviews before merging a PR into the master branch
+
+
 ## Unit & end-to-end tests
 
 There are two ways for running the tests.  The first listed works from the host machine, and the second works after `vagrant ssh` and `cd /vagrant`:
@@ -33,11 +44,3 @@ Also, the `npm start` command can include an additional `LNG` variable to serve 
 `LNG=es npm start`
 
 This would serve the app from the Spanish language files.
-
-## Project guidelines
-
-* Please check out [the project page](https://waffle.io/ole-vi/planet) for available tasks to work on.
-* Before contributing also be sure to read our [style guide](Style-Guide.md)
-* If you see something that needs work, please create an issue.  If the issue is on the frontend, please try to make it specific to one component.
-* To work on an issue, create a new branch with a descriptive title.
-* Please wait for at least two positive reviews before merging a PR into the master branch


### PR DESCRIPTION
Small update to the readme to bring the guidelines further up and highlight two additional points:

* Explicitly ask developers to clone rather than fork the repository.  Since the virtual interns fork for their work on the wiki, I'd like to highlight the difference here.
* Add a mention of the hooks.  This is included in the Style Guide as well, but I think it's good to mention it here, too.