### PR TITLE
Fix master build error

### DIFF
--- a/src/app/users/users-profile/users-profile.component.ts
+++ b/src/app/users/users-profile/users-profile.component.ts
@@ -13,6 +13,7 @@ export class UsersProfileComponent implements OnInit {
   imageSrc = '';
   urlPrefix = environment.couchAddress + this.dbName + '/';
   name = '';
+  roles = [];
   urlName = '';
 
   constructor(


### PR DESCRIPTION
A component property was missing causing `ng build` to fail.