### PR TITLE
~Use sh in our couchdb setup to make db-init docker in alpine can use it~ Add bash instead

### DIFF
--- a/docker/db-init/Dockerfile
+++ b/docker/db-init/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:6.11-alpine
 
 RUN apk update ;\
-    apk add --no-cache curl git jq ;\
+    apk add --no-cache bash curl git jq ;\
     #CORS DOWNLOAD
     npm install -g add-cors-to-couchdb
 

--- a/docker/db-init/rpi-Dockerfile
+++ b/docker/db-init/rpi-Dockerfile
@@ -1,6 +1,6 @@
 FROM hypriot/rpi-node:6.10.0-alpine
 RUN apk update ;\
-    apk add --no-cache curl git jq ;\
+    apk add --no-cache bash curl git jq ;\
     #CORS DOWNLOAD
     npm install -g add-cors-to-couchdb
 


### PR DESCRIPTION
Links to #324 

@Rupesh87 was changing the shebang of `couchdb-setup.sh` and it breaks our `db-init` docker since it doesn't has bash (it is an alpine linux container).

Is this shebang not sufficient in our vagrant? @dogi @paulbert 