### PR TITLE
[#404] Clean up imports

### DIFF
--- a/src/app/community/community.component.ts
+++ b/src/app/community/community.component.ts
@@ -1,10 +1,8 @@
 import { Component, OnInit, AfterViewInit, ViewChild } from '@angular/core';
-import { Location } from '@angular/common';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { CouchService } from '../shared/couchdb.service';
 import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
 import { MatTableDataSource, MatPaginator, MatDialog } from '@angular/material';
-import { switchMap } from 'rxjs/operators';
 
 @Component({
   templateUrl: './community.component.html'

--- a/src/app/courses/add-courses/courses-add.component.ts
+++ b/src/app/courses/add-courses/courses-add.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
   FormBuilder,
   FormControl,

--- a/src/app/feedback/feedback.directive.ts
+++ b/src/app/feedback/feedback.directive.ts
@@ -1,7 +1,5 @@
 import { Directive, HostListener } from '@angular/core';
 import { UserService } from '../shared/user.service';
-import { BrowserModule } from '@angular/platform-browser';
-import { FormsModule } from '@angular/forms';
 import { CouchService } from '../shared/couchdb.service';
 import { Validators } from '@angular/forms';
 import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';

--- a/src/app/nation/nation.component.ts
+++ b/src/app/nation/nation.component.ts
@@ -4,7 +4,6 @@ import { MatTableDataSource, MatSort, MatPaginator, MatDialog } from '@angular/m
 import { DialogsPromptComponent } from '../shared/dialogs/dialogs-prompt.component';
 import { DialogsViewComponent } from '../shared/dialogs/dialogs-view.component';
 import { DialogsFormService } from '../shared/dialogs/dialogs-form.service';
-import { DialogsFormComponent } from '../shared/dialogs/dialogs-form.component';
 import { HttpClient } from '@angular/common/http';
 import { PlanetMessageService } from '../shared/planet-message.service';
 import { Validators } from '@angular/forms';

--- a/src/app/resources/resources-add.component.ts
+++ b/src/app/resources/resources-add.component.ts
@@ -5,11 +5,9 @@ import {
   FormBuilder,
   FormControl,
   FormGroup,
-  FormArray,
   Validators
 } from '@angular/forms';
 import { CouchService } from '../shared/couchdb.service';
-import { CustomValidators } from '../validators/custom-validators';
 import { ValidatorService } from '../validators/validator.service';
 import * as constants from './resources-constants';
 

--- a/src/app/shared/dialogs/dialogs-form.service.ts
+++ b/src/app/shared/dialogs/dialogs-form.service.ts
@@ -4,8 +4,7 @@ import { MatDialogRef, MatDialog, MatDialogConfig } from '@angular/material';
 import { Injectable } from '@angular/core';
 import {
   FormBuilder,
-  FormGroup,
-  Validators
+  FormGroup
 } from '@angular/forms';
 
 @Injectable()

--- a/src/app/shared/dialogs/dialogs-form.service.ts
+++ b/src/app/shared/dialogs/dialogs-form.service.ts
@@ -4,9 +4,7 @@ import { MatDialogRef, MatDialog, MatDialogConfig } from '@angular/material';
 import { Injectable } from '@angular/core';
 import {
   FormBuilder,
-  FormControl,
   FormGroup,
-  FormArray,
   Validators
 } from '@angular/forms';
 

--- a/src/app/shared/planet-rating.component.ts
+++ b/src/app/shared/planet-rating.component.ts
@@ -1,8 +1,8 @@
-import { Component, HostBinding, forwardRef, Input, OnDestroy, ElementRef, Optional, Self } from '@angular/core';
+import { Component, HostBinding, Input, OnDestroy, Optional, Self } from '@angular/core';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { MatFormFieldControl } from '@angular/material';
 import { Subject } from 'rxjs/Subject';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR, FormControl, NgControl } from '@angular/forms';
+import { ControlValueAccessor, FormControl, NgControl } from '@angular/forms';
 
 @Component({
   selector: 'planet-rating',

--- a/src/app/shared/planet-rating.component.ts
+++ b/src/app/shared/planet-rating.component.ts
@@ -2,7 +2,7 @@ import { Component, HostBinding, Input, OnDestroy, Optional, Self } from '@angul
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { MatFormFieldControl } from '@angular/material';
 import { Subject } from 'rxjs/Subject';
-import { ControlValueAccessor, FormControl, NgControl } from '@angular/forms';
+import { ControlValueAccessor, NgControl } from '@angular/forms';
 
 @Component({
   selector: 'planet-rating',

--- a/src/app/users/users-update/users-update.component.ts
+++ b/src/app/users/users-update/users-update.component.ts
@@ -1,9 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import {
   FormBuilder,
-  FormControl,
   FormGroup,
-  FormArray,
   Validators
 } from '@angular/forms';
 import { CouchService } from '../../shared/couchdb.service';

--- a/src/app/validators/validator.service.ts
+++ b/src/app/validators/validator.service.ts
@@ -3,7 +3,6 @@ import { AbstractControl, ValidationErrors } from '@angular/forms';
 // Make sure not to import the entire rxjs library!!!
 import { Observable } from 'rxjs/Observable';
 import { timer } from 'rxjs/observable/timer';
-import { fromPromise } from 'rxjs/observable/fromPromise';
 
 import { findOneDocument } from '../shared/mangoQueries';
 import { CouchService } from '../shared/couchdb.service';


### PR DESCRIPTION
Besides my pull request, I am not sure the imports listed below should be cleaned up.

1) feedback.directive.ts
BrowserModule
formsModule

2) nation.component.ts
 DialogsFormComponent

3) shared/planet-rating.component.ts
 forwardRef
 ElementRef
 NG_VALUE_ACCESSOR
 FormControl