### PR TITLE
Remove unnecessary stopPropagation

### DIFF
--- a/src/app/courses/courses.component.html
+++ b/src/app/courses/courses.component.html
@@ -26,8 +26,7 @@
         </mat-checkbox>
       </mat-header-cell>
       <mat-cell *matCellDef="let row">
-        <mat-checkbox (click)="$event.stopPropagation()"
-          (change)="$event ? selection.toggle(row) : null"
+        <mat-checkbox (change)="$event ? selection.toggle(row) : null"
           [checked]="selection.isSelected(row)">
         </mat-checkbox>
       </mat-cell>

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -31,8 +31,7 @@
       </mat-checkbox>
       </mat-header-cell>
       <mat-cell *matCellDef="let row">
-        <mat-checkbox (click)="$event.stopPropagation()"
-          (change)="$event ? selection.toggle(row) : null"
+        <mat-checkbox (change)="$event ? selection.toggle(row) : null"
           [checked]="selection.isSelected(row)">
         </mat-checkbox>
       </mat-cell>

--- a/src/app/users/users.component.html
+++ b/src/app/users/users.component.html
@@ -33,8 +33,7 @@
       </mat-checkbox>
       </mat-header-cell>
       <mat-cell *matCellDef="let row">
-        <mat-checkbox (click)="$event.stopPropagation()"
-          (change)="$event ? selection.toggle(row) : null"
+        <mat-checkbox (change)="$event ? selection.toggle(row) : null"
           [checked]="selection.isSelected(row)">
         </mat-checkbox>
       </mat-cell>
@@ -61,7 +60,7 @@
         <mat-chip-list>
           <mat-chip *ngFor="let role of element.roles; index as i" [removable]="!element.isUserAdmin" (remove)="deleteRole(element,i)">
             {{role}}
-            <mat-icon matChipRemove *ngIf="!element.isUserAdmin" (click)="$event.stopPropagation()">cancel</mat-icon>
+            <mat-icon matChipRemove *ngIf="!element.isUserAdmin">cancel</mat-icon>
           </mat-chip>
           <mat-chip *ngIf="element.isUserAdmin">admin</mat-chip>
       </mat-chip-list>


### PR DESCRIPTION
We added a few unnecessary handlers to the select checkboxes in our tables.  In the Material docs these handlers are used in the examples because they also have a click in any part of the row toggle select.

If we don't have that or another overlapping click handler, we don't need these lines.