### PR TITLE
[#457] hide usersetting from users connects (#457)

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -3,7 +3,7 @@
   <button mat-icon-button (click)="toggleNav()" i18n-title title="Menu"><mat-icon>menu</mat-icon></button>
   <span>Planet Learning</span>
   <span class="toolbar-fill"></span>
-  <button mat-icon-button routerLink="/manager" i18n-title title="Manager Settings"><mat-icon svgIcon="usersettings"></mat-icon></button>
+  <button mat-icon-button *ngIf="isUserAdmin" routerLink="/manager" i18n-title title="Manager Settings"><mat-icon svgIcon="usersettings"></mat-icon></button>
   <button mat-icon-button *ngIf="notifications.length > 0" [matMenuTriggerFor]="notificationMenu" i18n-title title="Notifications"><mat-icon>notifications</mat-icon></button>
   <button mat-icon-button *ngIf="notifications.length === 0" i18n-title title="No Notification"><mat-icon>notifications</mat-icon></button>
   <button mat-icon-button [matMenuTriggerFor]="languageMenu">

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -32,6 +32,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   sidenavState = 'closed';
   notifications = [];
   @ViewChild('content') private mainContent;
+  isUserAdmin = false;
 
   // Sets the margin for the main content to match the sidenav width
   animObs = interval(15).debug('Menu animation').pipe(tap(() => {

--- a/src/app/manager-dashboard/manager-dashboard.component.ts
+++ b/src/app/manager-dashboard/manager-dashboard.component.ts
@@ -1,12 +1,26 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { UserService } from '../shared/user.service';
 
 @Component({
   template: `
-    <div><a routerLink="/community" i18n mat-raised-button>Communities</a> <a routerLink="/nation" i18n mat-raised-button>Nations</a></div>
+    <div *ngIf="displayDashboard"><a routerLink="/community" i18n mat-raised-button>Communities</a> <a routerLink="/nation" i18n mat-raised-button>Nations</a></div>
+    <div>{{message}}</div>
   `
 })
-export class ManagerDashboardComponent {
+export class ManagerDashboardComponent implements OnInit {
+  isUserAdmin = false;
+  displayDashboard = true;
+  message = '';
 
-  constructor() { }
+  constructor( private userService: UserService) { }
+
+  ngOnInit() {
+    Object.assign(this, this.userService.get());
+    if (!this.isUserAdmin) {
+      // A non-admin user cannot receive all user docs
+      this.displayDashboard = false;
+      this.message = 'Access restricted to admins';
+    }
+  }
 
 }


### PR DESCRIPTION
while setting up configuration its creating user without role, and it is adding isUserAdmin= true, therefore while checking roles its giving empty array[], thats why i have checked isUserAdmin for this issue. while creating user the value for isUserAdmin is false. so the manager setting button will be visible only if isUserAdmin is true