### PR TITLE
Configure center address for docker

### DIFF
--- a/docker/planet.yml
+++ b/docker/planet.yml
@@ -20,6 +20,7 @@ services:
       - HOST_PROTOCOL=http
       - DB_HOST=127.0.0.1
       - DB_PORT=2200
+      - CENTER_ADDRESS=earth.np.ole.org:5986
     depends_on:
       - couchdb
 version: "2"

--- a/docker/planet/docker-entrypoint.sh
+++ b/docker/planet/docker-entrypoint.sh
@@ -18,6 +18,7 @@ else
 fi
 
 sed -i -e "s#planet-db-port#$DB_PORT#g" /usr/share/nginx/html/main*
+sed -i -e "s#planet-center-address#$CENTER_ADDRESS#g" /usr/share/nginx/html/main*
 
 nginx -g "daemon off;"
 

--- a/docker/rpi-planet.yml
+++ b/docker/rpi-planet.yml
@@ -21,6 +21,7 @@ services:
       - HOST_PROTOCOL=http
       - DB_HOST=127.0.0.1
       - DB_PORT=2200
+      - CENTER_ADDRESS=earth.np.ole.org:5986
     depends_on:
       - couchdb
 version: "2"

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -3,5 +3,5 @@ export const environment = {
   test: false,
   // Change this to Docker address
   couchAddress: 'planet-db-host:planet-db-port/',
-  centerAddress: 'earth.np.ole.org:5986'
+  centerAddress: 'planet-center-address'
 };


### PR DESCRIPTION
Allows us to create production versions of planet with different center/earth address quickly.

