### PR TITLE
Fix Travis docker login prompt

### DIFF
--- a/.travis/travis_utils.sh
+++ b/.travis/travis_utils.sh
@@ -10,7 +10,7 @@ build_message(){
 }
 
 login_docker(){
-    docker login -u $DOCKER_USER -p $DOCKER_PASS
+  echo "$DOCKER_PASS" | docker login -u $DOCKER_USER --password-stdin
 }
 
 prepare_ci(){


### PR DESCRIPTION
See error in https://travis-ci.org/ole-vi/planet/jobs/364898667#L544

Found an alternative way to call `docker login` from https://docs.travis-ci.com/user/docker/#Pushing-a-Docker-Image-to-a-Registry