### PR TITLE
styling profile image update fixes #634

### DIFF
--- a/src/app/users/users-update/users-update.component.html
+++ b/src/app/users/users-update/users-update.component.html
@@ -65,7 +65,7 @@
       </div>
     </form>
     <div>
-      <img class="profile-image-large" [src]="previewSrc" >
+      <img class="profile-image-update" [src]="previewSrc">
       <div>
         <ngx-img (onSelect)="onImageSelect($event)" (onReset)="removeImageFile()" [config]="{ crop: [ { ratio: 1 } ] }"></ngx-img>
       </div>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -274,6 +274,13 @@ body {
     display: none;
   }
 
+  .profile-image-update {
+    border-radius: 50%;
+    margin-left: 2rem;
+    width: 14rem;
+    height: 14rem;
+  }
+
   .profile-image-large {
     border-radius: 50%;
     width: 70%;


### PR DESCRIPTION
This branch is just to fix the profile image becoming large after uploading a new profile image. I implemented it on my 564-ProfileImageCrop branch to test it before moving it to this new branch. There seems to be some kind of issue on this branch, I was unable to upload a new profile image using the old method. Also we should make this (and probably other parts of the app) more responsive, but that might warrant its own issue. 
![screenshot from 2018-04-19 17-37-01](https://user-images.githubusercontent.com/8280071/39024869-6c08a2c2-43f8-11e8-947e-17e2f6f6d0b6.png)
 